### PR TITLE
added ability to specify props that are nodes and also pass in defaul…

### DIFF
--- a/packages/example/src/ChildrenExample.js
+++ b/packages/example/src/ChildrenExample.js
@@ -10,6 +10,15 @@ export const Panel = ({ children, bold = false }) => (
   </div>
 )
 
+export const Other = () => (
+  <div>Other</div>
+)
+
+Other.displayName = 'Panel.Other'
+Other.propTypes = {}
+
+Panel.Other = Other
+
 Panel.propTypes = {
   children: PropTypes.arrayOf(PropTypes.node),
   bold: PropTypes.bool
@@ -23,15 +32,27 @@ Text.propTypes = {
   text: PropTypes.string.isRequired,
 }
 
-const ComponentUnderTest = ({ children, color }) => (
-  <div style={{ color }}>
-    {children}
-  </div>
-)
+const ComponentUnderTest = ({ children, color, header }) => {
+  if (header) {
+    return (
+      <div style={{ color }}>
+        {header}
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ color }}>
+      {children}
+    </div>
+  )
+}
 
 ComponentUnderTest.propTypes = {
   color: PropTypes.string.isRequired,
-  children: PropTypes.node
+  children: PropTypes.node,
+  header: PropTypes.node
 }
 
 export default ComponentUnderTest

--- a/packages/example/src/childrenExample.mdx
+++ b/packages/example/src/childrenExample.mdx
@@ -48,6 +48,6 @@ import ComponentUnderTest, { Panel, Text } from './ChildrenExample'
     />
   </svg>} />
 
-<ReactLiveProps of={ComponentUnderTest} additionalTitleText='Basic Usage' availableTypes={[Panel, Text, 'div']} />
+<ReactLiveProps of={ComponentUnderTest} additionalTitleText='Basic Usage' availableTypes={[Panel, Panel.Other, Text, 'div']} initialPropValues={{ header: <Text text='testing' />, color: 'red' }} />
 
 <ReactLiveProps of={Panel} additionalTitleText='Text Children' initialComponentChildren='Testing' />

--- a/packages/react-live-props/src/ComponentPreview/ComponentPreview.js
+++ b/packages/react-live-props/src/ComponentPreview/ComponentPreview.js
@@ -1,19 +1,43 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { SchemaContext } from '../Context'
-import { hasChildren, findSelectedType } from '../Utils'
+import { hasChildren, findSelectedType, getDisplayName, findNodeProperties } from '../Utils'
 
 import cs from 'classnames'
 
 import styles from './styles.css'
 
-const RenderComponent = ({ component, values, availableTypes }) => {
+const RenderComponent = ({ component, values, availableTypes, docgenInfo, htmlTypes }) => {
   // just in case they gave us default children which are already elements
   if (component['$$typeof']) {
     return component
   }
 
+  const componentDisplayName = getDisplayName(component)
+
   const { children, ...restValues } = values
+  let restValuesWithNodes = {
+    ...restValues
+  }
+  const nodeProperties = findNodeProperties(componentDisplayName, docgenInfo[componentDisplayName], htmlTypes).filter(name => name !== 'children')
+  nodeProperties.forEach(name => {
+    if (!values[name] || !values[name].type) {
+      restValuesWithNodes = {
+        ...restValuesWithNodes,
+        [name]: null
+      }
+
+      return
+    }
+    const propComponentType = values[name].type
+    const propValues = values[name][propComponentType]
+    const propComponent = findSelectedType(availableTypes, propComponentType)
+    restValuesWithNodes = {
+      ...restValuesWithNodes,
+      [name]: RenderComponent({ component: propComponent, values: { ...propValues, key: `${componentDisplayName}.${name}.${propComponentType}` }, availableTypes, docgenInfo, htmlTypes })
+    }
+  })
+
   if (hasChildren(values)) {
     if (Array.isArray(children)) {
       const childComponents = children.map((child, idx) => {
@@ -24,36 +48,58 @@ const RenderComponent = ({ component, values, availableTypes }) => {
         }
 
         const childComponent = findSelectedType(availableTypes, childDisplayName)
-        return RenderComponent({ component: childComponent, values: { ...childValues, key: `${childDisplayName}-${idx}` }, availableTypes })
+        return RenderComponent({ component: childComponent, values: { ...childValues, key: `${childDisplayName}-${idx}` }, availableTypes, docgenInfo, htmlTypes })
       })
 
-      return React.createElement(component, restValues, childComponents)
+      return React.createElement(component, restValuesWithNodes, childComponents)
     }
 
     const childDisplayName = children.type
     const childValues = children[childDisplayName]
 
     if (childDisplayName === '@@TEXT') {
-      return React.createElement(component, restValues, childValues.text)
+      return React.createElement(component, restValuesWithNodes, childValues.text)
     }
 
     const childComponent = findSelectedType(availableTypes, childDisplayName)
-    return RenderComponent({ component: childComponent, values: { ...childValues, key: childDisplayName }, availableTypes })
+    return React.createElement(component, restValuesWithNodes, RenderComponent({ component: childComponent, values: { ...childValues, key: childDisplayName }, availableTypes, docgenInfo, htmlTypes }))
   }
 
-  return React.createElement(component, restValues)
+  const renderedComponent = React.createElement(component, restValuesWithNodes)
+  return renderedComponent
 }
 
 RenderComponent.propTypes = {
   component: PropTypes.func.isRequired,
   values: PropTypes.object.isRequired,
-  availableTypes: PropTypes.array
+  availableTypes: PropTypes.array,
+  htmlTypes: PropTypes.array,
+  docgenInfo: PropTypes.object.isRequired
 }
 
 export default class ComponentPreview extends Component {
   static propTypes = {
     component: PropTypes.func.isRequired,
     className: PropTypes.string
+  }
+
+  state = {
+    hasError: false
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (prevState.hasError) {
+      return { hasError: false }
+    }
+
+    return prevState
+  }
+
+  componentDidCatch(error, info) {
+    console.error(JSON.stringify(error), info)
+    this.setState({
+      hasError: true
+    })
   }
 
   render() {
@@ -63,15 +109,21 @@ export default class ComponentPreview extends Component {
       ...rest
     } = this.props
 
+    if (this.state.hasError) {
+      return (
+        <p>There was an error rendering the component.  Check your props and try again.</p>
+      )
+    }
+
     return (
       <SchemaContext.Consumer>
-        {({ values, rootComponentDisplayName, availableTypes }) => {
+        {({ values, rootComponentDisplayName, availableTypes, docgenInfo, htmlTypes }) => {
           return (
             <div
               className={cs(className)}
               {...rest}
             >
-              <RenderComponent component={component} values={values[rootComponentDisplayName]} componentDisplayName={rootComponentDisplayName} availableTypes={availableTypes} />
+              <RenderComponent component={component} values={values[rootComponentDisplayName]} availableTypes={availableTypes} htmlTypes={htmlTypes} docgenInfo={docgenInfo} />
             </div>
           )
         }}

--- a/packages/react-live-props/src/Context/SchemaContext.js
+++ b/packages/react-live-props/src/Context/SchemaContext.js
@@ -1,3 +1,3 @@
 import React from 'react'
 
-export const SchemaContext = React.createContext({ schema: {}, values: {}, rootComponentDisplayName: null, editingComponent: null, editingComponentPath: '', htmlTypes: [], availableTypes: [] })
+export const SchemaContext = React.createContext({ schema: {}, values: {}, rootComponentDisplayName: null, editingComponent: null, editingComponentPath: '', htmlTypes: [], availableTypes: [], docgenInfo: null })

--- a/packages/react-live-props/src/EditablePropsTable/EditablePropsTable.js
+++ b/packages/react-live-props/src/EditablePropsTable/EditablePropsTable.js
@@ -90,7 +90,7 @@ export default class EditablePropsTable extends Component {
 
     return (
       <SchemaContext.Consumer>
-        {({ schema, values, editingComponent, editingComponentPath, htmlTypes }) => {
+        {({ schema, values, editingComponent, editingComponentPath, htmlTypes, docgenInfo }) => {
           const filteredSchema = this.filterProperties(schema[editingComponent])
           const propertyKeys = Object.keys(filteredSchema.properties)
           const currentValue = dotProp.get(values, editingComponentPath)
@@ -108,6 +108,7 @@ export default class EditablePropsTable extends Component {
                     parentName={editingComponentPath}
                     name={key}
                     value={propertyValue}
+                    docgenInfo={docgenInfo}
                     onChange={this._onChange}
                     onDelete={this._onDelete}
                     onAdd={this._onAdd}

--- a/packages/react-live-props/src/ReactLiveProps/styles.css
+++ b/packages/react-live-props/src/ReactLiveProps/styles.css
@@ -19,6 +19,11 @@
   border: 2px solid #e5e5e5;
 }
 
+.rlpEditablePropsTableTreeView {
+  max-height: 400px;
+  overflow: auto;
+}
+
 .rlpEditablePropsTable {
   display: flex;
 }
@@ -29,6 +34,8 @@
 
 .rlpEditablePropsTableMain {
   flex-grow: 1;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .rlpContainerTitle button {

--- a/packages/react-live-props/src/Renderers/Children.js
+++ b/packages/react-live-props/src/Renderers/Children.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { SchemaContext } from '../Context'
 import cs from 'classnames'
-import { buildDefaultValuesForType } from '../Utils'
+import { buildDefaultValuesForType, getDisplayName, getRawDisplayName } from '../Utils'
 
 import styles from './styles.css'
 
@@ -18,7 +18,7 @@ const onChangeType = async (schema, uniqueName, value, values, onChange, onDelet
 }
 
 export const ChildrenArrayRenderer = ({ value, uniqueName, name, onChange, onDelete }) => {
-  return <SchemaContext>
+  return <SchemaContext.Consumer>
     {({ schema, availableTypes, values }) => {
       if (availableTypes.length === 0) return null
 
@@ -33,9 +33,9 @@ export const ChildrenArrayRenderer = ({ value, uniqueName, name, onChange, onDel
                     <select key={`${uniqueName}.${idx}`} name={`${uniqueName}.${idx}`} value={child.type} onChange={(e) => onChangeType(schema, `${uniqueName}.${idx}`, e.target.value, values, onChange, onDelete)}>
                       <option value=''>none</option>
                       {availableTypes.map(availableType => {
-                        if (typeof availableType === 'string') return <option key={availableType} value={availableType}>{availableType}</option>
+                        if (typeof availableType === 'string') return <option key={getDisplayName(availableType)} value={getDisplayName(availableType)}>{getRawDisplayName(availableType)}</option>
 
-                        return <option key={availableType} value={availableType.name}>{availableType.name}</option>
+                        return <option key={getDisplayName(availableType)} value={getDisplayName(availableType)}>{getRawDisplayName(availableType)}</option>
                       })}
                     </select>
                   </div>
@@ -51,9 +51,9 @@ export const ChildrenArrayRenderer = ({ value, uniqueName, name, onChange, onDel
                 <select key={`${uniqueName}.${value.length}`} name={`${uniqueName}.${value.length}`} value='' onChange={(e) => onChangeType(schema, `${uniqueName}.${value.length}`, e.target.value, values, onChange, onDelete)}>
                   <option value=''>none</option>
                   {availableTypes.map(availableType => {
-                    if (typeof availableType === 'string') return <option key={availableType} value={availableType}>{availableType}</option>
+                    if (typeof availableType === 'string') return <option key={getDisplayName(availableType)} value={getDisplayName(availableType)}>{getRawDisplayName(availableType)}</option>
 
-                    return <option key={availableType} value={availableType.name}>{availableType.name}</option>
+                    return <option key={getDisplayName(availableType)} value={getDisplayName(availableType)}>{getRawDisplayName(availableType)}</option>
                   })}
                 </select>
               </div>
@@ -62,7 +62,7 @@ export const ChildrenArrayRenderer = ({ value, uniqueName, name, onChange, onDel
         </React.Fragment>
       )
     }}
-  </SchemaContext>
+  </SchemaContext.Consumer>
 }
 
 ChildrenArrayRenderer.propTypes = {
@@ -74,7 +74,7 @@ ChildrenArrayRenderer.propTypes = {
 }
 
 export const ChildrenObjectRenderer = ({ value, uniqueName, name, onChange, onDelete }) => {
-  return <SchemaContext>
+  return <SchemaContext.Consumer>
     {({ schema, availableTypes, values }) => {
       if (availableTypes.length === 0) return null
 
@@ -88,9 +88,9 @@ export const ChildrenObjectRenderer = ({ value, uniqueName, name, onChange, onDe
               <select key={uniqueName} name={uniqueName} value={valueOrDefault} onChange={(e) => onChangeType(schema, uniqueName, e.target.value, values, onChange, onDelete)}>
                 <option value=''>none</option>
                 {availableTypes.map(availableType => {
-                  if (typeof availableType === 'string') return <option key={availableType} value={availableType}>{availableType}</option>
+                  if (typeof availableType === 'string') return <option key={getDisplayName(availableType)} value={getDisplayName(availableType)}>{getRawDisplayName(availableType)}</option>
 
-                  return <option key={availableType} value={availableType.name}>{availableType.name}</option>
+                  return <option key={getDisplayName(availableType)} value={getDisplayName(availableType)}>{getRawDisplayName(availableType)}</option>
                 })}
               </select>
             </div>
@@ -98,7 +98,7 @@ export const ChildrenObjectRenderer = ({ value, uniqueName, name, onChange, onDe
         </div>
       )
     }}
-  </SchemaContext>
+  </SchemaContext.Consumer>
 }
 
 ChildrenObjectRenderer.propTypes = {

--- a/packages/react-live-props/src/Renderers/PrimitiveArray.js
+++ b/packages/react-live-props/src/Renderers/PrimitiveArray.js
@@ -12,7 +12,7 @@ const PrimitiveArrayRenderer = ({ parentName, name, property, value, onChange, o
   const newParentName = namespaceName(parentName, name)
 
   return (
-    <SchemaContext>
+    <SchemaContext.Consumer>
       {({ values }) => (
         <div className={cs('rlpProp', styles.rlpProp)}>
           <div className={cs('rlpPropHeader', styles.rlpPropHeader)}>
@@ -36,7 +36,7 @@ const PrimitiveArrayRenderer = ({ parentName, name, property, value, onChange, o
           </div>
         </div>
       )}
-    </SchemaContext>
+    </SchemaContext.Consumer>
   )
 }
 

--- a/packages/react-live-props/src/TreeView/TreeView.js
+++ b/packages/react-live-props/src/TreeView/TreeView.js
@@ -1,43 +1,59 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cs from 'classnames'
-import { hasChildren } from '../Utils'
+import { findNodeProperties, convertSafeDisplayNameToRaw, getDisplayName } from '../Utils'
 import { SchemaContext } from '../Context'
 
 import styles from './styles.css'
 
-const RenderComponent = ({ values, componentDisplayName, editingComponent, editingComponentPath, onChangeComponent, componentPath }) => {
-  const isSelected = editingComponentPath === componentPath
-
+const RenderComponent = ({ values, componentDisplayName, onChangeComponent, componentPath }) => {
   return (
-    <React.Fragment>
-      <li>
-        <p><a href='javascript:void(0)' className={isSelected ? cs('rlpTreeViewSelected', styles.rlpTreeViewSelected) : ''} onClick={() => onChangeComponent(componentDisplayName, componentPath)}>{componentDisplayName}</a></p>
-      </li>
-      {hasChildren(values) && (
-        <li className={cs('rlpTreeViewListContainer', styles.rlpTreeViewListContainer)}>
-          <ul>
-            {values && values.children && Array.isArray(values.children) && values.children.map((child, idx) => {
-              const newPath = `${componentPath}.children.${idx}.${child.type}`
+    <SchemaContext.Consumer>
+      {({ htmlTypes, docgenInfo, editingComponentPath }) => {
+        const isSelected = editingComponentPath === componentPath
+        return (
+          <React.Fragment>
+            <li>
+              <p><a href='javascript:void(0)' className={isSelected ? cs('rlpTreeViewSelected', styles.rlpTreeViewSelected) : ''} onClick={() => onChangeComponent(componentDisplayName, componentPath)}>{convertSafeDisplayNameToRaw(componentDisplayName)}</a></p>
+            </li>
+            {findNodeProperties(componentDisplayName, docgenInfo[componentDisplayName], htmlTypes).map((nodeProp, nodeIdx) => {
+              if (values && values[nodeProp]) {
+                if (Array.isArray(values[nodeProp]) && values[nodeProp].length === 0) return null
+
+                if (Object.keys(values[nodeProp]).length === 0) return null
+              } else {
+                return null
+              }
+
               return (
-                <RenderComponent key={`${child.type}-${idx}`} editingComponent={editingComponent} editingComponentPath={editingComponentPath} componentPath={newPath} values={values.children[idx][child.type]} componentDisplayName={child.type} onChangeComponent={onChangeComponent} />
+                <li className={cs('rlpTreeViewListContainer', styles.rlpTreeViewListContainer)} key={`${componentDisplayName}.${nodeProp}.${nodeIdx}`}>
+                  <div className={cs('rlpTreeViewPropContainer', styles.rlpTreeViewPropContainer)}>
+                    <p>{nodeProp}</p>
+                    <ul>
+                      {Array.isArray(values[nodeProp]) && values[nodeProp].map((child, idx) => {
+                        const newPath = `${componentPath}.${nodeProp}.${idx}.${child.type}`
+                        return (
+                          <RenderComponent key={`${child.type}-${idx}`} componentPath={newPath} values={values[nodeProp][idx][child.type]} componentDisplayName={getDisplayName(child.type)} onChangeComponent={onChangeComponent} />
+                        )
+                      })}
+                      {!Array.isArray(values[nodeProp]) && (
+                        <RenderComponent componentPath={`${componentPath}.${nodeProp}.${values[nodeProp].type}`} values={values[nodeProp][values[nodeProp].type]} componentDisplayName={getDisplayName(values[nodeProp].type)} onChangeComponent={onChangeComponent} />
+                      )}
+                    </ul>
+                  </div>
+                </li>
               )
             })}
-            {values && values.children && !Array.isArray(values.children) && (
-              <RenderComponent editingComponent={editingComponent} editingComponentPath={editingComponentPath} componentPath={`${componentPath}.children.${values.children.type}`} values={values.children[values.children.type]} componentDisplayName={values.children.type} onChangeComponent={onChangeComponent} />
-            )}
-          </ul>
-        </li>
-      )}
-    </React.Fragment>
+          </React.Fragment>
+        )
+      }}
+    </SchemaContext.Consumer>
   )
 }
 
 RenderComponent.propTypes = {
   values: PropTypes.object.isRequired,
   componentDisplayName: PropTypes.string.isRequired,
-  editingComponent: PropTypes.string.isRequired,
-  editingComponentPath: PropTypes.string.isRequired,
   onChangeComponent: PropTypes.func.isRequired,
   componentPath: PropTypes.string.isRequired
 }
@@ -53,11 +69,11 @@ class TreeView extends React.Component {
     const { of, className, onChangeComponent, ...rest } = this.props
 
     return <SchemaContext.Consumer>
-      {({ values, rootComponentDisplayName, editingComponent, editingComponentPath }) => {
+      {({ values, rootComponentDisplayName }) => {
         return (
           <div className={cs('rlpTreeView', styles.rlpTreeView, className)} {...rest}>
             <ul>
-              <RenderComponent values={values[rootComponentDisplayName]} editingComponentPath={editingComponentPath} componentPath={rootComponentDisplayName} editingComponent={editingComponent} componentDisplayName={rootComponentDisplayName} onChangeComponent={onChangeComponent} />
+              <RenderComponent values={values[rootComponentDisplayName]} componentPath={rootComponentDisplayName} componentDisplayName={rootComponentDisplayName} onChangeComponent={onChangeComponent} />
             </ul>
           </div>
         )

--- a/packages/react-live-props/src/TreeView/styles.css
+++ b/packages/react-live-props/src/TreeView/styles.css
@@ -9,8 +9,8 @@
   font-weight: bold;
 }
 
-.rlpTreeView ul { padding-left: 1em; }
-.rlpTreeView li  { padding-left: 1em;
+.rlpTreeView ul { padding-left: 0.5em; }
+.rlpTreeView li  { padding-left: 0.5em;
   border: 1px dotted black;
   border-width: 0 0 1px 1px;
 }
@@ -23,10 +23,14 @@
 }
 .rlpTreeView li ul {
   border-top: 1px dotted black;
-  margin-left: -1em;
-  padding-left: 2em;
+  margin-left: -0.5em;
+  padding-left: 1em;
 }
 .rlpTreeView ul li:last-child ul {
   border-left: 1px solid white;
   margin-left: -17px;
+}
+
+.rlpTreeViewPropContainer {
+  padding-left: 0.5em;
 }

--- a/packages/react-live-props/src/Utils/index.js
+++ b/packages/react-live-props/src/Utils/index.js
@@ -1,4 +1,4 @@
 export { namespaceName } from './namespace'
 export { tryParseStringAsType, tryConvertTypeToString } from './parser'
-export { findSelectedType, buildDefaultValuesForType, hasChildren, processReactElementToValue } from './types'
-export { getDisplayName } from './name'
+export { findSelectedType, buildDefaultValuesForType, hasChildren, processReactElementToValue, findNodeProperties } from './types'
+export { getDisplayName, getRawDisplayName, convertSafeDisplayNameToRaw } from './name'

--- a/packages/react-live-props/src/Utils/name.js
+++ b/packages/react-live-props/src/Utils/name.js
@@ -1,5 +1,33 @@
 export const getDisplayName = (Component) => {
+  if (typeof Component === 'string') return Component.replace(/\./g, '-')
+
+  if (typeof Component === 'symbol') {
+    const symbolString = Component.toString()
+    const sanitizedName = symbolString.replace('Symbol(', '').replace(')', '')
+    const nameParts = sanitizedName.split('.')
+    return nameParts.map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('-')
+  }
+
+  const name = Component.displayName || Component.name
+
+  if (name) {
+    return name.replace(/\./g, '-')
+  }
+
+  return null
+}
+
+export const getRawDisplayName = (Component) => {
   if (typeof Component === 'string') return Component
+
+  if (typeof Component === 'symbol') {
+    const symbolString = Component.toString()
+    const sanitizedName = symbolString.replace('Symbol(', '').replace(')', '')
+    const nameParts = sanitizedName.split('.')
+    return nameParts.map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('.')
+  }
 
   return Component.displayName || Component.name || null
 }
+
+export const convertSafeDisplayNameToRaw = (displayName) => displayName.replace(/-/g, '.')


### PR DESCRIPTION
…t values for props

* Props that are `PropTypes.node` or `PropTypes.arrayOf(PropTypes.node)` now get treated the same way as children.
* The TreeView on the left will now render children as well as any props that support nodes.  The prop name will be rendered before the list of elements.
* A new prop on RLP, `initialPropValues`, accepts an object that can be used to default values for any top-level properties, including complex JSX trees.  The giphy example below used this to set all of the values 
* Added support for React.Fragment as an element type